### PR TITLE
Fixed a typo on one of the examples

### DIFF
--- a/examples/lrsync.lua
+++ b/examples/lrsync.lua
@@ -5,7 +5,7 @@
 --
 settings = {
 	statusFile = "/tmp/lsyncd.stat",
-	statusIntervall = 1,
+	statusInterval = 1,
 }
 
 sync{


### PR DESCRIPTION
It had `statusIntervall` instead of `statusInterval`.
