### PR TITLE
correct small syntax error in default-direct.lua

### DIFF
--- a/default-direct.lua
+++ b/default-direct.lua
@@ -52,8 +52,8 @@ default.direct = {
 			end
 			spawn(event,
 				'/bin/cp',
-				event.sourcePath
-				event.targetPathdir,
+				event.sourcePath,
+				event.targetPathdir
 			)
 		elseif event.etype == 'Delete' then
 			if not config.delete then


### PR DESCRIPTION
<pre><code>
--- a/default-direct.lua
+++ b/default-direct.lua
@@ -52,8 +52,8 @@ default.direct = {
                        end
                        spawn(event,
                                '/bin/cp',
-                               event.sourcePath
-                               event.targetPathdir,
-                               event.sourcePath,
-                               event.targetPathdir
                      )
              elseif event.etype == 'Delete' then
                      if not config.delete then
  </pre></code>
