### PR TITLE
Simplify register functions

### DIFF
--- a/inotify.c
+++ b/inotify.c
@@ -351,7 +351,7 @@ inotify_ready(lua_State *L, struct observance *obs)
 extern void
 register_inotify(lua_State *L)
 {
-	luaL_register(L, "inotify", linotfylib);
+	luaL_register(L, LSYNCD_INOTIFYLIBNAME, linotfylib);
 }
 
 /**

--- a/lsyncd.c
+++ b/lsyncd.c
@@ -1368,8 +1368,8 @@ l_jiffies_le(lua_State *L)
 void
 register_lsyncd(lua_State *L)
 {
-	luaL_register(L, "lsyncd", lsyncdlib);
-	lua_setglobal(L, "lsyncd");
+	luaL_register(L, LSYNCD_LIBNAME, lsyncdlib);
+	lua_setglobal(L, LSYNCD_LIBNAME);
 
 	// creates the metatable for jiffies userdata
 	luaL_newmetatable(L, "Lsyncd.jiffies");
@@ -1393,9 +1393,9 @@ register_lsyncd(lua_State *L)
 	lua_pop(L, 1); // pop(mt)
 
 #ifdef LSYNCD_WITH_INOTIFY
-	lua_getglobal(L, "lsyncd");
+	lua_getglobal(L, LSYNCD_LIBNAME);
 	register_inotify(L);
-	lua_setfield(L, -2, "inotify");
+	lua_setfield(L, -2, LSYNCD_INOTIFYLIBNAME);
 	lua_pop(L, 1);
 #endif
 

--- a/lsyncd.h
+++ b/lsyncd.h
@@ -28,6 +28,9 @@
 #define LUA_USE_APICHECK 1
 #include <lua.h>
 
+#define LSYNCD_LIBNAME "lsyncd"
+#define LSYNCD_INOTIFYLIBNAME "inotify"
+
 /**
  * Lsyncd runtime configuration
  */


### PR DESCRIPTION
The register_lsyncd and register_inotify functions are bit more complex/difficult to read than necessary. These commits fix that.

This is based on my fix/lua52 branch.

In register_lsyncd as well as register_inotify I went from lua_settable to lua_setfield, which is a bit simpler to read. In register_lsyncd I also get a "pointer" (mt) to the metatable, so it is easier to call those functions with the right index.

Explanations copied from pullrequest #148:

``` patch
-   lua_pushstring(L, "inotify");
    luaL_newlib(L, linotfylib);
```

It was buggy before — newlib registers into the table on top of the stack, so pushstring before would break it. Happened because I did not pay enough attention when replacing register with newlib.

In addition I thought it might make sense if register_inotify would not push two values and expect it's caller to push them into a table as k=v, but if the caller would decide on the key. Seemed easier to read/understand as it is closer to normal Lua behaviour.

``` patch
-   lua_getglobal(L, "lysncd");
 #ifdef LSYNCD_WITH_INOTIFY
-   // TODO why is the here?
+   lua_getglobal(L, "lysncd");
    register_inotify(L);
-   lua_settable(L, -3);
-#endif
+   lua_setfield(L, -2, "inotify")
    lua_pop(L, 1);
+#endif
```

settable is then replaced by setfield to compensate for the removal of pushstring in register_inotify.

getglobal and pop are one pair, so it makes sense to have them both inside the ifdef. Otherwise the global would be pushed onto the stack and immediately be popped again.

In addition to those reasons, your comment "why is the here?" seemed to point to difficult understandability of the register_inotify function.
