### PR TITLE
Check for presence of lua and luac in configure and use path in Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,14 +46,14 @@ runner.o: runner.c
 defaults.o: defaults.c
 
 runner.c: runner.out bin2carray.lua
-	lua ./bin2carray.lua $< runner $@
+	$(LUA) ./bin2carray.lua $< runner $@
 
 defaults.c: defaults.out bin2carray.lua
-	lua ./bin2carray.lua $< defaults $@
+	$(LUA) ./bin2carray.lua $< defaults $@
 
 runner.out: lsyncd.lua
-	luac -o $@ $<
+	$(LUAC) -o $@ $<
 
 defaults.out: default.lua default-rsync.lua default-rsyncssh.lua default-direct.lua
-	luac -o $@ $^
+	$(LUAC) -o $@ $^
 

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,16 @@ PKG_CHECK_MODULES([LUA], [lua >= 5.1.3])
 ])
 ])
 
+AC_PATH_PROGS([LUA], [lua5.1 lua51 lua], [no])
+if test x${LUA} = xno ; then
+	AC_MSG_ERROR([Program 'lua' is required])
+fi
+
+AC_PATH_PROGS([LUAC], [luac5.1 luac51 luac], [no])
+if test x${LUAC} = xno ; then
+	AC_MSG_ERROR([Program 'luac' is required])
+fi
+
 ###
 # Checks for header files.
 AC_CHECK_HEADERS([sys/inotify.h])


### PR DESCRIPTION
This should help to prevent generating lua bytecode for a different version
 than the library being linked to. Not at all reliable, but a bit better
 than before.
