### PR TITLE
Adding --timeout to default.rsync

### DIFF
--- a/default-rsync.lua
+++ b/default-rsync.lua
@@ -76,6 +76,7 @@ rsync.checkgauge = {
 		rsync_path        =  true,
 		sparse            =  true,
 		temp_dir          =  true,
+		timeout           =  true,
         times             =  true,
 		update            =  true,
 		verbose           =  true,
@@ -478,6 +479,11 @@ rsync.prepare = function(
 
 	if crsync.temp_dir then
 		computed[ computedN ] = '--temp-dir=' .. crsync.temp_dir
+		computedN = computedN  + 1
+	end
+
+	if crsync.timeout then
+		computed[ computedN ] = '--timeout=' .. crsync.timeout
 		computedN = computedN  + 1
 	end
 


### PR DESCRIPTION
If the rsync server is flaky, the child rsync process can hang for a long time. Controlling the io timeout of rsync is useful in these situations.

However, I would ideally want lsyncd to quit when the child process returns with errors. But this behaviour seems to hold true only during init and not later. The events seem to get discarded even if rsync errors out.
