### PR TITLE
Fixes for parsing excludes file

### DIFF
--- a/lsyncd.lua
+++ b/lsyncd.lua
@@ -1384,7 +1384,9 @@ local Excludes = ( function( )
 
 			-- lsyncd 2.0 does not support includes
 
-			if not string.match(line, '^%s*%+') then
+			if not string.match(line, '^%s*%+') and
+					not string.match(line, '^%s*#') and
+					not string.match(line, '^%s*$') then
 				local p = string.match(
 					line, '%s*-?%s*(.*)'
 				)


### PR DESCRIPTION
Three commits:
- Fix filenames with "+" in them.
- Minor cosmetic change.
- Fix handling blank lines and comments.
