### PR TITLE
Fix for older kernels to make sure O_CLOEXEC is defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([lsyncd.c])
 AC_CONFIG_HEADER([config.h])
+AC_USE_SYSTEM_EXTENSIONS
 
 ###
 # Checks for programs.


### PR DESCRIPTION
This patch fixes an issue where I was getting build errors that O_CLOEXEC was undefined on an older 2.6.32 kernel. Even though the flag is supported in this kernel it was not getting defined.
