### PR TITLE
Typo in print format.

### DIFF
--- a/inotify.c
+++ b/inotify.c
@@ -143,7 +143,7 @@ l_addwatch( lua_State *L )
 
 		printlogf(
 			L, "Inotify",
-			"addwatch( %s )-> % d; err= %d : %s",
+			"addwatch( %s )-> %d; err= %d : %s",
 			path, wd, errno, strerror( errno )
 		);
 	}


### PR DESCRIPTION
This causes a segfault when addwatch fails on a disappeared directory. Eg: often caused by a race condition with a short lived directory created by Firefox' safebrowsing subsystem: ~/.cache/mozilla/firefox/pr0f1l3.default/safebrowsing-to_delete/
