### PR TITLE
Fix usage of settings in Lua 5.1

### DIFF
--- a/default-direct.lua
+++ b/default-direct.lua
@@ -143,7 +143,7 @@ direct.collect = function(agent, exitcode)
 		if rc == 'ok' then
 			log('Normal', 'Startup of "',agent.source,'" finished: ', exitcode)
 		elseif rc == 'again' then
-			if settings.insist then
+			if settings('insist') then
 				log('Normal', 'Retrying startup of "',agent.source,'": ', exitcode)
 			else
 				log('Error', 'Temporary or permanent failure on startup of "',

--- a/default-direct.lua
+++ b/default-direct.lua
@@ -147,7 +147,8 @@ direct.collect = function(agent, exitcode)
 				log('Normal', 'Retrying startup of "',agent.source,'": ', exitcode)
 			else
 				log('Error', 'Temporary or permanent failure on startup of "',
-				agent.source, '". Terminating since "insist" is not set.');
+				agent.source, '" (target: "', agent.target,
+				'"). Terminating since "insist" is not set.');
 				terminate(-1) -- ERRNO
 			end
 		elseif rc == 'die' then

--- a/default-rsyncssh.lua
+++ b/default-rsyncssh.lua
@@ -225,7 +225,8 @@ rsyncssh.collect = function( agent, exitcode )
 				log('Normal', 'Retrying startup of "',agent.source,'": ', exitcode)
 			else
 				log('Error', 'Temporary or permanent failure on startup of "',
-				agent.source, '". Terminating since "insist" is not set.');
+				agent.source, '" (target: "', agent.target,
+				'"). Terminating since "insist" is not set.');
 				terminate(-1) -- ERRNO
 			end
 

--- a/default.lua
+++ b/default.lua
@@ -116,7 +116,8 @@ default.collect = function( agent, exitcode )
 					'Error',
 					'Temporary or permanent failure on startup of "',
 					agent.source,
-					'". Terminating since "insist" is not set.'
+					'" (target: "', agent.target,
+					'"). Terminating since "insist" is not set.'
 				)
 
 				terminate( -1 )


### PR DESCRIPTION
Without 2eb0af0 I get:

<pre>
Jul  2 13:44:06 durandal lsyncd: Normal, recursive startup rsync: /home/plouj/ -> /media/plouj/Backup/home-backup/plouj/
Jul  2 13:44:07 durandal lsyncd: Error, in Lua: default-direct.lua:146: attempt to index global 'settings' (a function value)
Jul  2 13:44:07 durandal lsyncd: Error, Backtrace 1 :default-direct.lua:146
Jul  2 13:44:07 durandal lsyncd: Error, Backtrace 2 :lsyncd.lua:1544
Jul  2 13:44:07 durandal lsyncd: Error, Backtrace 3 :lsyncd.lua:3450
</pre>


And I have only tested 1b0ac95 with default-direct.lua. Please verify that my concatenation of strings is correct.
