### PR TITLE
fix lost file

### DIFF
--- a/lsyncd.lua
+++ b/lsyncd.lua
@@ -609,7 +609,7 @@ local Combiner = ( function( )
 			end
 
 			-- if one is a parent directory of another, events are blocking
-			if d1.path:byte(-1) == 47 and string.starts(d2.path, d1.path) or
+			if d1.path:byte(-1) == 47 and string.starts(d2.path, d1.path) and d1.etype ~= 'Attrib' or
 			   d2.path:byte(-1) == 47 and string.starts(d1.path, d2.path)
 			then
 				return 'stack'


### PR DESCRIPTION
When I try to run the following sequece of commands. fileA is lost on target host.

sync source is “/top”

```
cp bigfile /top/dirA/ &
mv /top/dirA/fileA /top/dirA/fileB
touch /top/dirA
cp fileC /top/dirA/fileA
```

If the higher directory’s attribute is changed, delete delay is not replaced by create delay.
