### PR TITLE
Properly sanitize mv parameters (CVE-2014-8990)

### DIFF
--- a/default-rsyncssh.lua
+++ b/default-rsyncssh.lua
@@ -77,8 +77,10 @@ rsyncssh.action = function( inlet )
 	-- makes move local on target host
 	-- if the move fails, it deletes the source
 	if event.etype == 'Move' then
-		local path1 = event.path:gsub ('"', '\\"'):gsub ('`', '\\`'):gsub ('%$','\\%$')
-		local path2 = event2.path:gsub ('"', '\\"'):gsub ('`', '\\`'):gsub ('%$','\\%$')
+		local path1 = config.targetdir .. event.path
+		local path2 = config.targetdir .. event2.path
+		path1 = "'" .. path1:gsub ('\'', '\'"\'"\'') .. "'"
+		path2 = "'" .. path2:gsub ('\'', '\'"\'"\'') .. "'"
 
 		log(
 			'Normal',
@@ -94,10 +96,10 @@ rsyncssh.action = function( inlet )
 			config.ssh._computed,
 			config.host,
 			'mv',
-			'\"' .. config.targetdir .. path1 .. '\"',
-			'\"' .. config.targetdir .. path2 .. '\"',
+			path1,
+			path2,
 			'||', 'rm', '-rf',
-			'\"' .. config.targetdir .. path1 .. '\"'
+			path1
 		)
 
 		return


### PR DESCRIPTION
This pulls in the improved patch by Ángel González angel@16bits.net, which is far more elegant than my initial approach and fixes additional problems (such as lua 5.2 compatibility).
