### PR TITLE
Updated lbash.lua and lrsync.lau to remove the equals (=)

### DIFF
--- a/examples/lbash.lua
+++ b/examples/lbash.lua
@@ -4,7 +4,7 @@
 -- This example uses local bash commands to keep two local
 -- directory trees in sync.
 --
-settings = {
+settings {
 	logfile         = "/tmp/lsyncd.log",
 	statusFile      = "/tmp/lsyncd.stat",
 	statusIntervall = 1,

--- a/examples/lrsync.lua
+++ b/examples/lrsync.lua
@@ -3,7 +3,7 @@
 --
 -- Simple example for default rsync.
 --
-settings = {
+settings {
 	statusFile = "/tmp/lsyncd.stat",
 	statusInterval = 1,
 }


### PR DESCRIPTION
Per the change to have settings be a function instead of a variable, I updated the example files to reflect this update.