### PR TITLE
Docs: Correct spelling of "insist"

### DIFF
--- a/manual/config/file/index.md
+++ b/manual/config/file/index.md
@@ -68,7 +68,7 @@ Valid keys for settings are:
 </td><td> syslog identification (tag), default "lsyncd"
 </td></tr>
 
- <tr><td> insisit
+ <tr><td> insist
 </td><td> =
 </td><td> true
 </td><td> keep running at startup altough one or more targets failed due to not being reachable.

--- a/manual/config/file/index.md
+++ b/manual/config/file/index.md
@@ -71,7 +71,7 @@ Valid keys for settings are:
  <tr><td> insist
 </td><td> =
 </td><td> true
-</td><td> keep running at startup altough one or more targets failed due to not being reachable.
+</td><td> keep running at startup although one or more targets failed due to not being reachable.
 </td></tr>
 
  <tr><td> inotifyMode


### PR DESCRIPTION
Typo in the docs.