### PR TITLE
Docs: Add "archive" to table of rsync options

### DIFF
--- a/manual/config/layer4/index.md
+++ b/manual/config/layer4/index.md
@@ -80,6 +80,12 @@ Below is a table of options for the ```rsync``` parameter. Please have a look at
 </td><td> (Lsyncd >= 2.2.0)
 </td></tr>
 
+ <tr><td> archive
+</td><td> =
+</td><td> true
+</td><td>
+</td></tr>
+
  <tr><td> backup
 </td><td> =
 </td><td> true


### PR DESCRIPTION
The current table listing options for the rsync parameter fails to list the "archive" option, despite it being conspicuously used in most of the example configs.