### PR TITLE
Fix documented default value of `nodeamon` flag

### DIFF
--- a/manual/config/file/index.md
+++ b/manual/config/file/index.md
@@ -40,7 +40,7 @@ Valid keys for settings are:
 
  <tr><td> nodaemon
 </td><td> =
-</td><td> true
+</td><td> false
 </td><td> does not detach
 </td></tr>
 


### PR DESCRIPTION
By default `lsyncd` lunches demonized - document that.