### PR TITLE
Make the CI run tests successfully again

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,14 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - lsyncd_lua5_3
-          # broken with lua 5.4.4. luac segfault
-          # - lsyncd_lua5_4
-          - lsyncd_lua5_1
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: cachix/install-nix-action@v15
-      - run: chmod og-rw ~
-      - run: nix develop .#${{ matrix.version }} --command ./tests/ci-run.sh
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        # lua 5.1 is the default currently, 5.3 is supported but while 5.4 is available in the repo, luarocks has not been compiled against it
+        run: sudo apt-get install --no-install-recommends asciidoc cmake docbook-xml docbook-xsl liblua5.3-dev libxml2-dev libxml2-utils lua5.3 pkg-config xsltproc lua-posix
+      - name: Install luarocks
+        run: sudo apt-get install --no-install-recommends luarocks
+      - name: Run luarocks to get not-packaged dependency
+        run: sudo luarocks install lua-crontab
+      - name: Fixup build dir rights
+        run: chmod og-rw ~
+      - name: Fixup lua tree rights
+        run: sudo chmod -R a+rX /usr/local/share/lua/
+      - name: Build and run tests
+        run: ./tests/ci-run.sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,7 @@ name: "Build"
 on:
   pull_request:
   push:
+  workflow_dispatch:
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/tests/ci-run.sh
+++ b/tests/ci-run.sh
@@ -4,7 +4,7 @@ set -ex
 
 function cleanup() {
         echo "** abort. cleanup ssh server"
-        cd `dirname $BASH_SOURCE`/..
+        cd `dirname $BASH_SOURCE`/.. || exit 0
         # CLEANUP=`dirname $BASH_SOURCE`/../teardown.lua
         lua tests/teardown.lua
 }
@@ -18,4 +18,5 @@ cd $BUILD_FOLDER
 cmake $SRC
 make VERBOSE=1
 make run-tests
+cd ~
 rm -rf $BUILD_FOLDER


### PR DESCRIPTION
Hi Daniel,

This PR makes the tests run successfully again.
I have removed the nix dependency as we don't use that. This now tests against Lua 5.3 on Ubuntu-latest as that is the highest version supported by the stock luarocks (which is needed for the unpackaged lua-crontab¹).

I would be willing to take over maintenance for lsyncd if you still want to get it off your chest. We use it at my company.

¹ I think this should get packaged after the Trixie release which would make luarocks unnecessary for the test runs again after a another year or two. {Debian, Ubuntu} release cycles...

Best,
/DLange
